### PR TITLE
feat: set up PostgreSQL database configuration and initialization scripts

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,0 +1,7 @@
+# Database
+DB_PORT=5432
+DB_HOST=database // In Docker use 'database' as hostname, otherwise 'localhost'
+DB_USERNAME=postgres
+DB_PASSWORD=postgres
+DB_DATABASE=smart_secretary
+ENABLE_ORM_LOGS=true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,56 @@
+# compiled output
+/dist
+/node_modules
+/build
+
+# Logs
+logs
+*.log
+npm-debug.log*
+pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# OS
+.DS_Store
+
+# Tests
+/coverage
+/.nyc_output
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# dotenv environment variable files
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
+
+# temp directory
+.temp
+.tmp
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Diagnostic reports (https://nodejs.org/api/report.html)
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  db:
+    build: postgres
+    container_name: db
+    volumes:
+    - ./postgres:/docker-entrypoint-initdb.d
+    environment:
+      POSTGRES_USER: $DB_USERNAME
+      POSTGRES_PASSWORD: $DB_PASSWORD
+      POSTGRES_MULTIPLE_DATABASES: $DB_DATABASE
+      TZ: "GMT"
+      PGTZ: "GMT"
+    ports:
+      - "$DB_PORT:$DB_PORT"

--- a/postgres/001_create-multiple-postgresql-databases.sh
+++ b/postgres/001_create-multiple-postgresql-databases.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -e
+set -u
+
+create_user_and_database() {
+  database=$1
+  echo "  Creating user and database '$database'"
+  psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+	    CREATE USER $database;
+	    CREATE DATABASE $database;
+	    GRANT ALL PRIVILEGES ON DATABASE $database TO $database;
+EOSQL
+  psql -d $database -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+      CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+EOSQL
+}
+
+if [ -n "$POSTGRES_MULTIPLE_DATABASES" ]; then
+  echo "Multiple database creation requested: $POSTGRES_MULTIPLE_DATABASES"
+  for db in $(echo $POSTGRES_MULTIPLE_DATABASES | tr ',' ' '); do
+    create_user_and_database $db
+  done
+  echo "Multiple databases created"
+fi

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,0 +1,2 @@
+FROM postgres
+COPY 001_create-multiple-postgresql-databases.sh /docker-entrypoint-initdb.d/


### PR DESCRIPTION
This pull request introduces a local PostgreSQL database setup using Docker Compose, making it easier to manage and run the database in development environments. The changes include configuration files, a Docker setup for PostgreSQL, and a script to initialize multiple databases with required extensions.

**Database setup and configuration:**

* Added a `.env-sample` file with environment variables for PostgreSQL connection settings, including host, port, username, password, database name, and ORM logging flag.
* Updated `docker-compose.yml` to define a `db` service that builds from a custom `postgres` directory, sets up environment variables from `.env`, maps ports, and mounts initialization scripts.

**Database initialization and Docker image:**

* Added a `postgres/Dockerfile` to extend the official PostgreSQL image and copy the initialization script into the container.
* Introduced `postgres/001_create-multiple-postgresql-databases.sh`, a shell script that creates users and databases as specified by the environment variable, and enables the `uuid-ossp` extension for each database.